### PR TITLE
Remove styles for streaming lookup container

### DIFF
--- a/skins/elegantKefin.css
+++ b/skins/elegantKefin.css
@@ -1,10 +1,3 @@
-.layout-desktop .streaming-lookup-container {
-    position: absolute;
-    bottom: 100%;
-	z-index: 2;
-	margin: 0 !important;
-}
-
 .layout-desktop  .nextUpSection.verticalSection.detailVerticalSection {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This is causing the container to be positioned weirdly in elegant fin

With
<img width="1632" height="415" alt="image" src="https://github.com/user-attachments/assets/92a57dec-56a0-4c43-8b7f-9ed242178732" />


After removing

<img width="1865" height="624" alt="image" src="https://github.com/user-attachments/assets/0242d84a-3a3d-4911-956c-b330c53dd32c" />
