### PR TITLE
Add margin-right for the series-info container

### DIFF
--- a/scripts/seriesInfo.js
+++ b/scripts/seriesInfo.js
@@ -221,6 +221,7 @@
         const infoContainer = document.createElement('div');
         infoContainer.className = 'kt-series-info';
         infoContainer.style.display = 'flex';
+        infoContainer.style.margin = '0 1em 0 0';
 
         // Seasons count (only show if more than 1 season)
         const childCount = item.ChildCount || 0;


### PR DESCRIPTION
When the extra media info items are being added, depending on what is added when, Jellyfin decides the last item and applies the last-child CSS

```css
[dir=ltr] .mediaInfoItem:last-child {
    margin-right: 0;
}
```

This is causing the lack of margin between the series info and the info items added via Enhanced

<img width="843" height="117" alt="image" src="https://github.com/user-attachments/assets/fbf255a8-8ace-4d75-a8bc-275571e476c9" />

So adding that margin regardless if it is the last item or not, I have pushed a similar change for JE https://github.com/n00bcodr/Jellyfin-Enhanced/commit/55d208415384fb6e0dfcda6cf64139d8cd1a3c26
