### PR TITLE
fix: added emby-button class to section headings for inheriting some missing styles from Jellyfin

### DIFF
--- a/scripts/cardBuilder.js
+++ b/scripts/cardBuilder.js
@@ -1464,7 +1464,7 @@
         if (viewMoreUrl) {
             // Create clickable title with chevron icon
             const titleLink = document.createElement('a');
-            titleLink.className = 'sectionTitle-link sectionTitleTextButton';
+            titleLink.className = 'sectionTitle-link emby-button sectionTitleTextButton';
             titleLink.style.cssText = 'text-decoration: none; cursor: pointer; display: flex; align-items: center;';
             
             // Handle both URL and function


### PR DESCRIPTION
Type of change: Bugfix

Description: This change adds a class named `emby-button` to `.sectionTitleTextButton`. Jellyfin also adds these classes together by default in many cases. Some themes like ElegantFin use `emby-button` to apply some styles too.

<hr>

Without this fix:

<img width="422" height="77" alt="image" src="https://github.com/user-attachments/assets/5516600e-478c-4da4-bb7f-0efda1c845f0" />

<img width="474" height="118" alt="image" src="https://github.com/user-attachments/assets/a787b876-afab-49d1-9618-c77781ba4bfb" />

<hr>

With this fix:

<img width="440" height="71" alt="image" src="https://github.com/user-attachments/assets/0281e777-3764-4d00-804d-79c84af8f49e" />

<img width="494" height="121" alt="image" src="https://github.com/user-attachments/assets/f594b751-6bab-41ef-a55c-21782a31da41" />

<hr>

**EDIT**

I've just noticed, this class already exists in the experimental branch. Feel free to close this PR if this is irrelevant.

