### PR TITLE
fix(seriesEpisodes): ElegantFin-compatible full-bleed row + scroll buttons

### DIFF
--- a/scripts/seriesEpisodes.css
+++ b/scripts/seriesEpisodes.css
@@ -1,3 +1,54 @@
+/* Series episodes row (KefinTweaks)
+ *
+ * Works with stock Jellyfin and ElegantFin.
+ * Do not clip the section with overflow:hidden — that prevents full-bleed
+ * width and traps .emby-scrollbuttons (position:absolute; right:0) inside
+ * a padded/narrow box instead of the page edge.
+ */
+
 .nextUpSection {
     display: none;
+}
+
+.series-episodes-section,
+.custom-scroller-container.series-episodes-section {
+    overflow: visible !important;
+    position: relative;
+    box-sizing: border-box;
+    /* Full viewport width so horizontal scroller + < > use the page edge */
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+    grid-column: 1 / -1;
+}
+
+.series-episodes-section > .sectionTitleContainer,
+.series-episodes-section .sectionTitleContainer-cards {
+    padding-left: var(--sidePadding, 3.3%);
+    padding-right: var(--sidePadding, 3.3%);
+    box-sizing: border-box;
+}
+
+.series-episodes-section > .emby-scroller,
+.series-episodes-section .custom-scroller {
+    overflow-x: auto;
+    overflow-y: visible;
+    width: 100%;
+    max-width: none;
+    padding-left: var(--sidePadding, 3.3%);
+    padding-right: var(--sidePadding, 3.3%);
+    box-sizing: border-box;
+}
+
+/* Jellyfin: .emby-scroller-container { position: relative }
+   .emby-scrollbuttons { position: absolute; right: 0; top: 0 }
+   With a full-bleed section, right:0 is the page edge. */
+.series-episodes-section > .emby-scrollbuttons,
+.series-episodes-section .emby-scrollbuttons {
+    position: absolute;
+    top: 0;
+    right: max(0.25em, calc(var(--sidePadding, 3.3%) - 0.5em));
+    left: auto;
+    z-index: 5;
 }

--- a/scripts/seriesEpisodes.js
+++ b/scripts/seriesEpisodes.js
@@ -536,8 +536,11 @@
         const hideSingleSeasonContainer = window.KefinTweaksConfig?.flattenSingleSeasonShows?.hideSingleSeasonContainer === true;
 
         // ElegantFin handling :)
+        // NOTE: do NOT set overflow:hidden on the section — it clips the
+        // horizontal episode scroller and prevents full-bleed page width.
+        // Keep overflow on the inner .emby-scroller only (browser default).
         seasonSection.style.cssText = `
-            overflow: hidden;
+            overflow: visible;
             display: block;
         `;
 

--- a/scripts/seriesEpisodes.js
+++ b/scripts/seriesEpisodes.js
@@ -535,13 +535,14 @@
         
         const hideSingleSeasonContainer = window.KefinTweaksConfig?.flattenSingleSeasonShows?.hideSingleSeasonContainer === true;
 
-        // ElegantFin handling :)
-        // NOTE: do NOT set overflow:hidden on the section — it clips the
-        // horizontal episode scroller and prevents full-bleed page width.
-        // Keep overflow on the inner .emby-scroller only (browser default).
+        // ElegantFin / full-bleed layout (see seriesEpisodes.css).
+        // Never set overflow:hidden here — it clips the horizontal scroller
+        // and traps .emby-scrollbuttons inside a narrow padded box so < >
+        // do not sit on the page's right edge.
         seasonSection.style.cssText = `
             overflow: visible;
             display: block;
+            position: relative;
         `;
 
         const scrollerContainer = seasonSection.querySelector('.emby-scroller');


### PR DESCRIPTION
## Summary

Fixes KefinTweaks **series episodes** layout with **ElegantFin** (and any full-bleed detail theme).

**Closes #116**

## Problems (with ElegantFin)

1. **`overflow: hidden`** set inline on `.series-episodes-section` (“ElegantFin handling”) **clips** the horizontal episode scroller so it cannot span full page width.
2. **`.emby-scrollbuttons`** are `position: absolute; right: 0` on `.emby-scroller-container { position: relative }`. If the section is only as wide as padded detail content, **`<` `>` sit inset** instead of on the right edge of the list/page.

## Changes

| File | Change |
|------|--------|
| `scripts/seriesEpisodes.js` | `overflow: visible` + `position: relative` — never `hidden` on the section |
| `scripts/seriesEpisodes.css` | Full-bleed section (`100vw` / breakout), padded title/scroller, scroll buttons on section right |

Horizontal scrolling remains on the inner `.emby-scroller` / `.custom-scroller`.

## Test plan

- [ ] Jellyfin 10.11 + KefinTweaks series episodes + ElegantFin
- [ ] Series detail: episode row spans full width (not clipped)
- [ ] `<` `>` on the right side of the full-width row
- [ ] Multi-season selector still works
- [ ] Stock theme (no ElegantFin): no regression

## Refs

- Issue: #116  
- ElegantFin nightly already notes `.series-episodes-section` support (`grid-column: 1 / -1`)